### PR TITLE
add with clause to load_test()

### DIFF
--- a/checklist/abstract_test.py
+++ b/checklist/abstract_test.py
@@ -9,7 +9,8 @@ from .viewer.test_summarizer import TestSummarizer
 
 def load_test(file):
     dill._dill._reverse_typemap['ClassType'] = type
-    return dill.load(open(file, 'rb'))
+    with open(file, 'rb') as infile:
+        return dill.load(infile)
 
 def read_pred_file(path, file_format=None, format_fn=None, ignore_header=False):
     f = open(path, 'r', encoding='utf-8')


### PR DESCRIPTION
`load_test()` doesn't have a file close operation when loading a test suite from file, which raises this warning
```
/Users/rchandrasekara/repos/checklist/checklist/abstract_test.py:12: ResourceWarning: unclosed file <_io.BufferedReader name='guardrail/behavioral_test/serialized/trial'>
  return dill.load(open(file, 'rb'))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
So, I have wrapped the `dill.load()` line inside a `with` clause to safely close the file after opening. 