### PR TITLE
Added test_id param to test types

### DIFF
--- a/checklist/abstract_test.py
+++ b/checklist/abstract_test.py
@@ -67,7 +67,7 @@ def read_pred_file(path, file_format=None, format_fn=None, ignore_header=False):
 class AbstractTest(ABC):
     def __init__(self, data, expect, labels=None, meta=None, agg_fn='all',
                  templates=None, print_first=None, name=None, capability=None,
-                 description=None):
+                 description=None, test_id=None):
         self.data = data
         self.expect = expect
         self.labels = labels
@@ -80,6 +80,7 @@ class AbstractTest(ABC):
         self.name = name
         self.capability = capability
         self.description = description
+        self.test_id = test_id
     def save(self, file):
         dill.dump(self, open(file, 'wb'), recurse=True)
 

--- a/checklist/test_types.py
+++ b/checklist/test_types.py
@@ -3,7 +3,7 @@ from .expect import Expect
 
 class MFT(AbstractTest):
     def __init__(self, data, expect=None, labels=None, meta=None, agg_fn='all',
-                 templates=None, name=None, capability=None, description=None):
+                 templates=None, name=None, capability=None, description=None, test_id=None):
         """Minimum Functionality Test
 
         Parameters
@@ -28,6 +28,8 @@ class MFT(AbstractTest):
             test capability
         description : str
             test description
+        test_id: str
+            test case identifier
         """
         if labels is None and expect is None:
             raise(Exception('Must specify either \'expect\' or \'labels\''))
@@ -35,12 +37,12 @@ class MFT(AbstractTest):
             expect = Expect.eq()
         super().__init__(data, expect, labels=labels, meta=meta, agg_fn=agg_fn,
                          templates=templates, print_first=False, name=name,
-                         capability=capability, description=description)
+                         capability=capability, description=description, test_id=test_id)
 
 class INV(AbstractTest):
     def __init__(self, data, expect=None, threshold=0.1, meta=None,
                  agg_fn='all_except_first', templates=None, name=None,
-                 capability=None, description=None, labels=None):
+                 capability=None, description=None, labels=None, test_id=None):
         """Invariance Test
 
         Parameters
@@ -69,16 +71,18 @@ class INV(AbstractTest):
             test description
         labels : single value (int, str, etc) or list
             If list, must be the same length as data
+        test_id: str
+            test case identifier
         """
         if expect is None:
             expect = Expect.inv(threshold)
         super().__init__(data, expect, labels=labels, meta=meta, agg_fn=agg_fn,
                          templates=templates, print_first=True, name=name,
-                         capability=capability, description=description)
+                         capability=capability, description=description, test_id=test_id)
 
 class DIR(AbstractTest):
     def __init__(self, data, expect, meta=None, agg_fn='all_except_first',
-                 templates=None, name=None, labels=None, capability=None, description=None):
+                 templates=None, name=None, labels=None, capability=None, description=None, test_id=None):
         """Directional Expectation Test
 
         Parameters
@@ -103,7 +107,9 @@ class DIR(AbstractTest):
             test capability
         description : str
             test description
+        test_id: str
+            test case identifier
         """
         super().__init__(data, expect, labels=labels, meta=meta, agg_fn=agg_fn,
                          templates=templates, print_first=True, name=name,
-                         capability=capability, description=description)
+                         capability=capability, description=description, test_id=test_id)

--- a/tests/test_test_types.py
+++ b/tests/test_test_types.py
@@ -1,0 +1,51 @@
+"""unit tests for test suite creation with different test types"""
+from unittest import TestCase
+from checklist.test_types import MFT, DIR, INV
+from checklist.editor import Editor
+from checklist.expect import Expect
+
+
+class TestTestTypes(TestCase):
+    editor = Editor()
+    dummy_test_data = editor.template(
+        templates=["example 1", "example 2"], meta=False, labels=["label1", "label2"])
+    test_id = "100"
+
+    def test_mft_w_test_id(self):
+        mft_test = MFT(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="mft test with test id",
+                       test_id=self.test_id)
+        assert mft_test.test_id == self.test_id
+
+    def test_mft_wo_test_id(self):
+        mft_test = MFT(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="mft test without test id")
+        assert mft_test.test_id is None
+
+    def test_dir_w_test_id(self):
+        dir_test = DIR(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="dir test with test id",
+                       test_id=self.test_id)
+        assert dir_test.test_id == self.test_id
+
+    def test_dir_wo_test_id(self):
+        dir_test = DIR(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="dir test without test id")
+        assert dir_test.test_id is None
+
+    def test_inv_w_test_id(self):
+        inv_test = INV(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="inv test with test id",
+                       test_id=self.test_id)
+        assert inv_test.test_id == self.test_id
+
+    def test_inv_wo_test_id(self):
+        inv_test = INV(**self.dummy_test_data,
+                       expect=Expect.eq(),
+                       name="inv test without test id")
+        assert inv_test.test_id is None


### PR DESCRIPTION
In addition to `test_name` and `description`, a unique test identifier is often assigned to quickly identify different test cases. I have added a new optional `test_id` keyword argument to `abstract_test` as well as `MFT, DIR, INV` classes. Also, I created a `tests` directory with unit tests that check object creation succeeds with and without this new argument. Please merge if you feel this could be useful.