### PR TITLE
fixed check_call() for whitespace in Windows path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from subprocess import check_call
 import sys
 import os
 def enable_visual_interface():
-    check_call(f"{sys.executable} -m pip install jupyter", shell=True)
+    check_call(f'"{sys.executable}"'+" -m pip install jupyter", shell=True)
     import notebook
     notebook.nbextensions.install_nbextension_python(
         "checklist.viewer", user=True, overwrite=True)


### PR DESCRIPTION
For a path like "C:\Hello World\python.exe", check call will send C:\Hello World\python.exe -m pip install jupyter to Windows shell. However, windows shell will trim the command at the end of Hello due to whitespace following it. Hence, Windows will throw error "C:\Hello" not recognized as a command

To overcome this, a pair of double quotes has to be placed around the path. The change does so by adding quotes around the path. The command sent to shell will be "C:\Hello World\python.exe" -m pip install jupyter. The shell will not break the command at whitespace as the entire path is now enclosed in double quotes.

This change will not affect Linux and MacOS as both OS support execution thru path files enclosed with double quotes.