### PR TITLE
Add lexicon from csv

### DIFF
--- a/notebooks/CSV Lexicon Example.ipynb
+++ b/notebooks/CSV Lexicon Example.ipynb
@@ -14,7 +14,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Demonstrate basic functionality"
+    "## How to add a lexicon from CSV\n",
+    "To add a lexicon from csv, use the function `editor.add_lexicon_from_csv(tag_name, csv_file_path)`"
    ]
   },
   {
@@ -45,7 +46,7 @@
     {
      "data": {
       "text/plain": [
-       "MunchWithAdd({'meta': [{'mypeople': MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'})}, {'mypeople': MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'})}, {'mypeople': MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'})}, {'mypeople': MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'})}, {'mypeople': MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'})}], 'data': ['John is 18 years old and has an income of $5000', 'Steve is 50 years old and has an income of $1000000', 'Yukiko is 38 years old and has an income of $50000', 'Guowei is 28 years old and has an income of $380000', 'Benoit is 66 years old and has an income of $98250']})"
+       "MunchWithAdd({'meta': [{'mypeople': MunchWithAdd({'name': 'John', 'age': '20', 'income': '10000'})}, {'mypeople': MunchWithAdd({'name': 'Steve', 'age': '30', 'income': '20000'})}, {'mypeople': MunchWithAdd({'name': 'Yukiko', 'age': '40', 'income': '30000'})}, {'mypeople': MunchWithAdd({'name': 'Guowei', 'age': '50', 'income': '40000'})}, {'mypeople': MunchWithAdd({'name': 'Benoit', 'age': '60', 'income': '50000'})}], 'data': ['John is 20 years old and has an income of $10000', 'Steve is 30 years old and has an income of $20000', 'Yukiko is 40 years old and has an income of $30000', 'Guowei is 50 years old and has an income of $40000', 'Benoit is 60 years old and has an income of $50000']})"
       ]
      },
      "execution_count": 4,
@@ -61,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Demonstrate error handling"
+    "## Demonstrate errors"
    ]
   },
   {
@@ -142,16 +143,16 @@
     {
      "data": {
       "text/plain": [
-       "[MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
-       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'}),\n",
-       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
-       " MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
-       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'}),\n",
-       " MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
-       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'}),\n",
-       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
-       " MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
-       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'})]"
+       "[MunchWithAdd({'name': 'John', 'age': '20', 'income': '10000'}),\n",
+       " MunchWithAdd({'name': 'Steve', 'age': '30', 'income': '20000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '40', 'income': '30000'}),\n",
+       " MunchWithAdd({'name': 'Guowei', 'age': '50', 'income': '40000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '60', 'income': '50000'}),\n",
+       " MunchWithAdd({'name': 'John', 'age': '20', 'income': '10000'}),\n",
+       " MunchWithAdd({'name': 'Steve', 'age': '30', 'income': '20000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '40', 'income': '30000'}),\n",
+       " MunchWithAdd({'name': 'Guowei', 'age': '50', 'income': '40000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '60', 'income': '50000'})]"
       ]
      },
      "execution_count": 8,
@@ -173,11 +174,11 @@
     {
      "data": {
       "text/plain": [
-       "[MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
-       " MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
-       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
-       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'}),\n",
-       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'})]"
+       "[MunchWithAdd({'name': 'Steve', 'age': '30', 'income': '20000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '60', 'income': '50000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '40', 'income': '30000'}),\n",
+       " MunchWithAdd({'name': 'Guowei', 'age': '50', 'income': '40000'}),\n",
+       " MunchWithAdd({'name': 'John', 'age': '20', 'income': '10000'})]"
       ]
      },
      "execution_count": 9,
@@ -190,13 +191,6 @@
     "editor.add_lexicon_from_csv(\"mypeople\", \"lex.csv\", append=True, remove_duplicates=True)\n",
     "editor.lexicons['mypeople']"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/CSV Lexicon Example.ipynb
+++ b/notebooks/CSV Lexicon Example.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import checklist\n",
+    "from checklist.editor import Editor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demonstrate basic functionality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "editor = Editor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "editor.add_lexicon_from_csv(\"mypeople\", \"lex.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MunchWithAdd({'meta': [{'mypeople': MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'})}, {'mypeople': MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'})}, {'mypeople': MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'})}, {'mypeople': MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'})}, {'mypeople': MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'})}], 'data': ['John is 18 years old and has an income of $5000', 'Steve is 50 years old and has an income of $1000000', 'Yukiko is 38 years old and has an income of $50000', 'Guowei is 28 years old and has an income of $380000', 'Benoit is 66 years old and has an income of $98250']})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "editor.template(\"{mypeople.name} is {mypeople.age} years old and has an income of ${mypeople.income}\", meta=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Demonstrate error handling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "Exception",
+     "evalue": "Length of row 1 does not match header length (4 != 3)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-6078a63e8a31>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Error: CSV with incorrect formatting (row length doesn't match header length)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0meditor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_lexicon_from_csv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mypeople\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"bad_lex.csv\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/code/checklist/checklist/editor.py\u001b[0m in \u001b[0;36madd_lexicon_from_csv\u001b[0;34m(self, name, path, overwrite, append, remove_duplicates)\u001b[0m\n\u001b[1;32m    594\u001b[0m                     \u001b[0md\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    595\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrow\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcol_names\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 596\u001b[0;31m                         \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Length of row {i} does not match header length ({len(row)} != {len(col_names)})'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    597\u001b[0m                     \u001b[0;32mfor\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mval\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0menumerate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrow\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    598\u001b[0m                         \u001b[0md\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_names\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mj\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mval\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: Length of row 1 does not match header length (4 != 3)"
+     ]
+    }
+   ],
+   "source": [
+    "# Error: CSV with incorrect formatting (row length doesn't match header length)\n",
+    "editor.add_lexicon_from_csv(\"mypeople\", \"bad_lex.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'unknown_lex.csv'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-6-34edd2531b1d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Error: CSV file doesn't exist\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0meditor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_lexicon_from_csv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mypeople\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"unknown_lex.csv\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/code/checklist/checklist/editor.py\u001b[0m in \u001b[0;36madd_lexicon_from_csv\u001b[0;34m(self, name, path, overwrite, append, remove_duplicates)\u001b[0m\n\u001b[1;32m    585\u001b[0m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    586\u001b[0m         \u001b[0mcol_names\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 587\u001b[0;31m         \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnewline\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m''\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    588\u001b[0m             \u001b[0mreader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcsv\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    589\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrow\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0menumerate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreader\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'unknown_lex.csv'"
+     ]
+    }
+   ],
+   "source": [
+    "# Error: CSV file doesn't exist\n",
+    "editor.add_lexicon_from_csv(\"mypeople\", \"unknown_lex.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "Exception",
+     "evalue": "mypeople already in lexicons. Call with overwrite=True to overwrite",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-04b8fffa92ec>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Error: Attempt overwrite without specifying overwrite=True\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0meditor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_lexicon_from_csv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mypeople\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"lex.csv\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/code/checklist/checklist/editor.py\u001b[0m in \u001b[0;36madd_lexicon_from_csv\u001b[0;34m(self, name, path, overwrite, append, remove_duplicates)\u001b[0m\n\u001b[1;32m    598\u001b[0m                         \u001b[0md\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_names\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mj\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mval\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    599\u001b[0m                     \u001b[0mvalues\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mMunchWithAdd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0md\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 600\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd_lexicon\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0moverwrite\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mappend\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mremove_duplicates\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mremove_duplicates\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    601\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    602\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_get_fillin_items\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mall_keys\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmax_count\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/code/checklist/checklist/editor.py\u001b[0m in \u001b[0;36madd_lexicon\u001b[0;34m(self, name, values, overwrite, append, remove_duplicates)\u001b[0m\n\u001b[1;32m    563\u001b[0m             \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    564\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mname\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlexicons\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 565\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'%s already in lexicons. Call with overwrite=True to overwrite'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    566\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlexicons\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    567\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: mypeople already in lexicons. Call with overwrite=True to overwrite"
+     ]
+    }
+   ],
+   "source": [
+    "# Error: Attempt overwrite without specifying overwrite=True\n",
+    "editor.add_lexicon_from_csv(\"mypeople\", \"lex.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
+       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
+       " MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'}),\n",
+       " MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
+       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
+       " MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'})]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Add lexicon again with append = True (resulting in duplicates)\n",
+    "editor.add_lexicon_from_csv(\"mypeople\", \"lex.csv\", append=True)\n",
+    "editor.lexicons['mypeople']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[MunchWithAdd({'name': 'Guowei', 'age': '28', 'income': '380000'}),\n",
+       " MunchWithAdd({'name': 'John', 'age': '18', 'income': '5000'}),\n",
+       " MunchWithAdd({'name': 'Yukiko', 'age': '38', 'income': '50000'}),\n",
+       " MunchWithAdd({'name': 'Benoit', 'age': '66', 'income': '98250'}),\n",
+       " MunchWithAdd({'name': 'Steve', 'age': '50', 'income': '1000000'})]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Add lexicon with remove_duplicates = True, showing removing duplicates works with munches in the lexicon\n",
+    "editor.add_lexicon_from_csv(\"mypeople\", \"lex.csv\", append=True, remove_duplicates=True)\n",
+    "editor.lexicons['mypeople']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/bad_lex.csv
+++ b/notebooks/bad_lex.csv
@@ -1,0 +1,2 @@
+name,age,income
+John,Doe,100,3

--- a/notebooks/lex.csv
+++ b/notebooks/lex.csv
@@ -1,0 +1,6 @@
+name,age,income
+John,20,10000
+Steve,30,20000
+Yukiko,40,30000
+Guowei,50,40000
+Benoit,60,50000


### PR DESCRIPTION
Adds a new function to the Editor, `add_lexicon_from_csv`, that adds a new lexicon tag from a CSV file. 

The new functionality is documented in this notebook:
https://github.com/Nking92/checklist/blob/csv_lexicon/notebooks/CSV%20Lexicon%20Example.ipynb

I also implemented `__hash__` for MunchWithAdd so removing duplicates will work with munches in the lexicon.