### PR TITLE
add build-system requires after PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "jupyter"]  # PEP 518 specifications.

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools.command.build_py import build_py
 
 from subprocess import check_call
 import sys
-import os
+
+import notebook
+
 def enable_visual_interface():
-    check_call(f'"{sys.executable}"'+" -m pip install jupyter", shell=True)
-    import notebook
     notebook.nbextensions.install_nbextension_python(
         "checklist.viewer", user=True, overwrite=True)
     notebook.nbextensions.enable_nbextension_python(


### PR DESCRIPTION
Specifies the build requires after pep518, so installments won't be broken.
Fixes https://github.com/marcotcr/checklist/issues/119

Notice that https://github.com/marcotcr/checklist/pull/134 also fixes the issue by disabling jupyter, however I think that this PR would still be usefull even if that other PR gets merged.