### PR TITLE
use pycountry instead of iso639

### DIFF
--- a/checklist/multilingual.py
+++ b/checklist/multilingual.py
@@ -1,15 +1,11 @@
 import collections
-from iso639 import languages
+from pycountry import languages
+
 def get_language_code(language):
-    to_try = [languages.name, languages.inverted, languages.part1]
-    l_to_try = [language.capitalize(), language.lower()]
-    for l in l_to_try:
-        for t in to_try:
-            if l in t:
-                if not t[l].part1:
-                    continue
-                return t[l].part1
-    raise Exception('Language %s not recognized. Try the iso-639 code.' % language)
+    try:
+        return languages.lookup(language).alpha_2
+    except LookupError:
+        raise Exception('Language %s not recognized. Try the iso-639 code.' % language)
 
 def multilingual_params(language, **kwargs):
     language_code = get_language_code(language)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(name='checklist',
         'ipywidgets>=7.5',
         'transformers>=2.8',
         'patternfork-nosql',
-        'iso-639'
+        'pycountry'
       ],
       cmdclass={
         'develop': PostDevelopCommand,


### PR DESCRIPTION
use pycountry over iso639 for 2 reasons:

* iso639 is [compatible](https://github.com/noumar/iso639#compatibility) with an older version of pycountry, so it makes sense to use the more recent version to be more up to date.
* iso639 had its last commit more than 7 years ago, leaving the package seemingly unmaintained. According to their [classifiers](https://github.com/noumar/iso639/blob/master/setup.py#L41) it does only support python3.5 or lower, meaning that it officially doesn't support any maintained python version. While you can still install that package via pip, modern package managers like poetry look at the compatibility information and therefore reject the installation. Hence, dropping iso639 would allow checklist gain greater support by dropping iso639 in favour of pycountry.